### PR TITLE
Bump com.github.ezTxmMC:ezLib from 1.0-ALPHA6 to 1.0-ALPHA10

### DIFF
--- a/velosystem-core/pom.xml
+++ b/velosystem-core/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>com.github.ezTxmMC</groupId>
             <artifactId>ezLib</artifactId>
-            <version>1.0-ALPHA6</version>
+            <version>1.0-ALPHA10</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
Bumps com.github.ezTxmMC:ezLib from 1.0-ALPHA6 to 1.0-ALPHA10.

---
updated-dependencies:
- dependency-name: com.github.ezTxmMC:ezLib dependency-type: direct:production ...